### PR TITLE
Fix copying splash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1030,7 +1030,7 @@ exports.build = function(builder, project, opts, next) {
 	}, function() {
 		copyIcons(builder, manifest.ios.icons, destPath);
 		copyFonts(builder, manifest.ttf, destPath);
-		copySplash(builder, project, destPath, f.wait());
+		copySplash(builder, manifest, destPath, f.wait());
 	}, function() {
 		// If IPA generation was requested,
 		if (argv.ipa) {


### PR DESCRIPTION
Splash wasn't getting copied. Simple error - wrong argument being passed to the copySplash function.
