### PR TITLE
Support push notifications for iOS8

### DIFF
--- a/tealeaf/platform/TeaLeafAppDelegate.mm
+++ b/tealeaf/platform/TeaLeafAppDelegate.mm
@@ -90,8 +90,19 @@
 	self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 	[self.window makeKeyAndVisible];
 
-    [app registerForRemoteNotificationTypes:
-     (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+	//-- Set Notification
+	if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0)
+	{
+		[app registerUserNotificationSettings:
+			[UIUserNotificationSettings settingsForTypes:
+			(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge) categories:nil]];
+		[app registerForRemoteNotifications];
+	}
+	else
+	{
+		[app registerForRemoteNotificationTypes:
+			(UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+	}
 
 	//TEALEAF_SPECIFIC_START
 	self.tealeafViewController = [[TeaLeafViewController alloc] init];
@@ -451,7 +462,9 @@
 
 - (void) application: (UIApplication *) app didRegisterForRemoteNotificationsWithDeviceToken: (NSData *) deviceToken
 {
-    [self.pluginManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken application:app];
+	NSLOG(@"{notifications} Push notification registration successful: %@", deviceToken);
+
+	[self.pluginManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken application:app];
 }
 
 - (void) application: (UIApplication *) app didFailToRegisterForRemoteNotificationsWithError: (NSError *) error

--- a/tealeaf/platform/TeaLeafAppDelegate.mm
+++ b/tealeaf/platform/TeaLeafAppDelegate.mm
@@ -91,15 +91,12 @@
 	[self.window makeKeyAndVisible];
 
 	//-- Set Notification
-	if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0)
-	{
+	if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
 		[app registerUserNotificationSettings:
 			[UIUserNotificationSettings settingsForTypes:
 			(UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge) categories:nil]];
 		[app registerForRemoteNotifications];
-	}
-	else
-	{
+	} else {
 		[app registerForRemoteNotificationTypes:
 			(UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
 	}


### PR DESCRIPTION
The old api for registering notifications has been deprecated in iOS8.
This adds a conditional registration based on what platform it is being built for