### PR TITLE
fix (package.json): add sh to preinstall command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "xcode": "^0.6.7"
   },
   "scripts": {
-    "preinstall": "./preinstall.sh"
+    "preinstall": "sh ./preinstall.sh"
   },
   "private": true,
   "repository": {


### PR DESCRIPTION
Explicitly call preinstall.sh with the sh command
to help installations work on windows.
