### PR TITLE
[jsDialog] Button with UTF-8 label causes a crash app

### DIFF
--- a/tealeaf/js/jsDialog.mm
+++ b/tealeaf/js/jsDialog.mm
@@ -42,7 +42,7 @@ JSAG_MEMBER_BEGIN(_showDialog, 5)
 	for (int i = 0; i < buttonCount; ++i) {
 		JS_GetElement(cx, btns, i, el);
     JS::RootedString str(cx, JS::ToString(cx, el));
-		buttons[i] = JS_EncodeString(cx, str);
+		buttons[i] = JS_EncodeStringToUTF8(cx, str);
 	}
 	
 	dialog_show_dialog(title, text, image, buttons, buttonCount, callbacks, cbCount);


### PR DESCRIPTION
Dialog button with UTF-8 label causes a crash app.

```
Uncaught exception: UIAlertView: Buttons added must have a title.
2015-02-03 13:07:28.568 TeaLeafIOS[34558:118366] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIAlertView: Buttons added must have a title.'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010ca3af35 __exceptionPreprocess + 165
	1   libobjc.A.dylib                     0x000000010c14bbb7 objc_exception_throw + 45
	2   CoreFoundation                      0x000000010ca3ad9a +[NSException raise:format:arguments:] + 106
	3   Foundation                          0x000000010ade55df -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 195
	4   UIKit                               0x0000000109638706 -[UIAlertView addButtonWithTitle:] + 117
	5   TeaLeafIOS                          0x00000001079ec503 dialog_show_dialog + 275
	6   TeaLeafIOS                          0x0000000107a3ea27 _ZL23jsag_member__showDialogP9JSContextjPN2JS5ValueE + 711
	7   TeaLeafIOS                          0x0000000107bdd38f _ZN2js6InvokeEP9JSContextN2JS8CallArgsENS_14MaybeConstructE + 431
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```