### PR TITLE
Should allow user define variables outside 'addons' block in manifest

### DIFF
--- a/lib/updatePlist.js
+++ b/lib/updatePlist.js
@@ -6,7 +6,7 @@ var getUserDefinedValue = function(manifest, key) {
   if (/\./.test(key)) {
     //its a . separated key
     var keys = key.split('.');
-    keys.unshift('addons');
+    // keys.unshift('addons');#allow user define variable outside addons block
     var obj = manifest;
     keys.forEach(function(k) {
       obj = obj && obj[k];


### PR DESCRIPTION
The keys.unshift('addons') code forces us to add the custom variables in addons block.
I think we should allow user defines the variables both inside and outside addons block to get more flexible.
Example:
```json
{
  "plist": {
     "foo": "bar${addons.baz.qux}",
     "FacebookAppID": "$(ios.facebookAppID)",
     "FacebookDisplayName": "$(ios.facebookDisplayName)",
     "CFBundleURLTypes.CFBundleURLSchemes": "fb$(ios.facebookAppID)"
  }
}
```