### PR TITLE
Feature additional linker flag

### DIFF
--- a/lib/xcodeUtil.js
+++ b/lib/xcodeUtil.js
@@ -143,6 +143,42 @@ Project.prototype.installModule = function (modulePath, config, cb) {
     }, this);
   }
 
+  if (config.additionalLinkerFlags) {
+    var linkerFlagKey = 'OTHER_LDFLAGS';
+    logger.log(
+      "Updating xcode project with additional linker flags",
+     config.additionalLinkerFlags
+    );
+
+    // if one string flag, convert to array of flags
+    if (typeof config.additionalLinkerFlags === 'string') {
+      config.additionalLinkerFlags = [config.additionalLinkerFlags];
+    }
+
+    var projectConfig = this._project.pbxXCBuildConfigurationSection();
+    var projectKeys = Object.keys(projectConfig);
+
+    for (var i = 0; i < projectKeys.length; i++) {
+      var projectKey = projectKeys[i];
+      var buildSettings = projectConfig[projectKey].buildSettings;
+      if (buildSettings) {
+        var linkerFlags = buildSettings[linkerFlagKey] || [];
+
+        // if linkerFlags is a string, make it a list
+        if (typeof linkerFlags === 'string') {
+          linkerFlags = [linkerFlags];
+        }
+
+        config.additionalLinkerFlags.forEach(function(flag) {
+          linkerFlags.push('"' + flag + '"');
+        });
+
+        projectConfig[projectKey].buildSettings[linkerFlagKey] = linkerFlags;
+      }
+    }
+
+  }
+
   var frameworks = config.frameworks || [];
   frameworks.forEach(function(framework) {
     if (isFramework(framework)) {

--- a/lib/xcodeUtil.js
+++ b/lib/xcodeUtil.js
@@ -129,6 +129,13 @@ Project.prototype.installModule = function (modulePath, config, cb) {
 
   if (config.arccode) {
     config.arccode.forEach(function(file) {
+      // show warning if already added in code
+      if (config.code && config.code.indexOf(file) !== -1) {
+        logger.warn(
+          'Cannot set ARC compiler flag for ' + file + '.',
+          'Already added in "code" section.')
+      }
+
       if (isHeaderFile(file)) {
         this._project.addHeaderFile(this.getRelativePath(modulePath, file), {
           compilerFlags: '-fobjc-arc'


### PR DESCRIPTION
- Add `additionalLinkerFlags` option to module config.
- Add warning for files added to both `code` and `arccode` lists