### PR TITLE
add disableBitcode flag to module config

### DIFF
--- a/lib/xcodeUtil.js
+++ b/lib/xcodeUtil.js
@@ -190,6 +190,19 @@ Project.prototype.installModule = function (modulePath, config) {
     }
   }
 
+  if (config.disableBitcode) {
+    var projectConfig = this._project.pbxXCBuildConfigurationSection();
+    var projectKeys = Object.keys(projectConfig);
+
+    for (var i = 0; i < projectKeys.length; i++) {
+      var projectKey = projectKeys[i];
+      var buildSettings = projectConfig[projectKey].buildSettings;
+      if (buildSettings) {
+        projectConfig[projectKey].buildSettings.ENABLE_BITCODE = false;
+      }
+    }
+  }
+
   var frameworks = config.frameworks || [];
   frameworks.forEach(function(framework) {
     if (isFramework(framework)) {


### PR DESCRIPTION
If any module has the disableBitcode flag in config.json, the final xcodeproject
will have EnableBitcode set to false. This is necessary for older modules that
have not yet been updated to support bitcode enabled builds.