### PR TITLE
copy specified resources and bundles from modules

### DIFF
--- a/lib/xcodeUtil.js
+++ b/lib/xcodeUtil.js
@@ -219,6 +219,15 @@ Project.prototype.installModule = function (modulePath, config) {
     }, this);
   }
 
+  var resources = config.resources || [];
+  resources.forEach(function(resource) {
+    var res_path = path.join(modulePath, resource);
+    if (modulePath && fs.existsSync(res_path)) {
+      filesToCopy.push(resource);
+      this._project.addResourceFile(resource, {plugin: true});
+    }
+  }, this);
+
   return Promise
     .resolve(filesToCopy)
     .bind(this)
@@ -229,8 +238,8 @@ Project.prototype.installModule = function (modulePath, config) {
     });
 };
 
-Project.prototype.addResourceFiles = function(resourcePath) {
-  this._project.addResourceFile(resourcePath);
+Project.prototype.addResourceFiles = function(resourcePath, opts) {
+  this._project.addResourceFile(resourcePath, opts);
   return Promise.resolve();
 };
 


### PR DESCRIPTION
We had a third party sdk which needed their bundles to be copied inside xcode project. 

This allows devkit modules specify and copy custom .bundle files for ios build.

Resources can be specified in `config.json` as follows,

```
{
  "code": [
  ],
  "frameworks": [
  ],
  "resources": [
    "en.lproj",
    "file1.bundle",
    "file2.bundle"
  ]
}
```
